### PR TITLE
Add jets grids with kfactor and ren_sv included

### DIFF
--- a/data/grids/4001/ATLAS_1JET_8TEV_R06.pineappl.lz4
+++ b/data/grids/4001/ATLAS_1JET_8TEV_R06.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c15cc3b5bf2eb54fd4a8ddbacc35d85e412eeeb656e66fbf20c252a59c6d6d39
+size 22595463

--- a/data/grids/4001/ATLAS_2JET_7TEV_R06.pineappl.lz4
+++ b/data/grids/4001/ATLAS_2JET_7TEV_R06.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b441a41060de9581b5919b7b0281a18f206c62aefed7242a238edc4a5157991
+size 12804562

--- a/data/grids/4001/CMS_1JET_8TEV-CMS_1JET_8TEV.pineappl.lz4
+++ b/data/grids/4001/CMS_1JET_8TEV-CMS_1JET_8TEV.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1850e0306797647f0a9d9b56bd73b10b938debb6bd0c5a7c99595ca5147250bf
+size 31687637

--- a/data/grids/4001/CMS_2JET_7TEV.pineappl.lz4
+++ b/data/grids/4001/CMS_2JET_7TEV.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:154a982721c2918aea341326d3acc77fdc04a06e02b4353171f3e35a43baf072
+size 6976468

--- a/data/grids/4005/ATLAS_1JET_8TEV_R06.pineappl.lz4
+++ b/data/grids/4005/ATLAS_1JET_8TEV_R06.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:228ea8012ba12f5c95c0de52f6a09317303be9f46b864a2aeaf3ae1a4f2070c0
+size 11412883

--- a/data/grids/4005/ATLAS_2JET_7TEV_R06.pineappl.lz4
+++ b/data/grids/4005/ATLAS_2JET_7TEV_R06.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9de3e3dbed0ed2a3dce3db6d327efb7f3f8003d080cbe06de1fecd3e40fd0f6
+size 6323152

--- a/data/grids/4005/CMS_1JET_8TEV-CMS_1JET_8TEV.pineappl.lz4
+++ b/data/grids/4005/CMS_1JET_8TEV-CMS_1JET_8TEV.pineappl.lz4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5f54042b5903533a3711a39563f3f977356d89dbefa750083a5ba66ec1ebdb7d
+oid sha256:eed3f2d54316e6d863b26287ac57dc1a7cae0c3cd2ae4f9eac88d6aa53377827
 size 15855390

--- a/data/grids/4005/CMS_2JET_7TEV.pineappl.lz4
+++ b/data/grids/4005/CMS_2JET_7TEV.pineappl.lz4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cabd9ee2399bf3e309368ded056a249ed8ad384ec42ba845b6062856f33dc751
+size 3377839


### PR DESCRIPTION
I added

- jets grids with nlo_ren_sv included (using `automatic_sv` from `pineko`) in the folder `4005`
- jets grids with both NNLO kfactor and nnlo_ren_sv included (using `automatic_sv` and `kfactor` from `pineko`) in `4001`

They are for sure useful also for @giacomomagni and (maybe) for @niclaurenti 